### PR TITLE
Fix-click-to-add-point

### DIFF
--- a/table-tools-script/dgc-table-tools.user.js
+++ b/table-tools-script/dgc-table-tools.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        DesmosTableTools
 // @namespace   slidav.Desmos
-// @version     1.1.4
+// @version     1.1.5
 // @author      SlimRunner (David Flores)
 // @description Adds tools to manipulate tables
 // @grant       none

--- a/table-tools-script/dgc-table-tools.user.js
+++ b/table-tools-script/dgc-table-tools.user.js
@@ -90,7 +90,7 @@
 				
 				if (
 					VtxAdder.getIndex() !== -1 &&
-					e.ctrlKey &&
+					e.ctrlKey || e.altKey || e?.metaKey &&
 					e.buttons === 1
 				) {
 					

--- a/table-tools-script/dgc-table-tools.user.js
+++ b/table-tools-script/dgc-table-tools.user.js
@@ -227,14 +227,16 @@
 			
 			--lastIdx;
 			
-			if (
-				expr.columns[0].values[lastIdx] &&
-				expr.columns[1].values[lastIdx]
-			) {
-				return VtxAdder.TableState.NO_TRAIL;
-			} // !if
+			//Desmos seem to not add empty heads anymore
+			return VtxAdder.TableState.NO_TRAIL
+			// if (
+			// 	expr.columns[0].values[lastIdx] &&
+			// 	expr.columns[1].values[lastIdx]
+			// ) {
+			// 	return VtxAdder.TableState.NO_TRAIL;
+			// } // !if
 			
-			return VtxAdder.TableState.HAS_TRAIL;
+			// return VtxAdder.TableState.HAS_TRAIL;
 		},
 		
 		
@@ -383,7 +385,7 @@
 					group : [{
 						tag : 'i',
 						classes : [
-							'dcg-icon-cursor'
+							'dcg-icon-points'
 						]
 					}]
 				}, {


### PR DESCRIPTION
Fix issue with points not being added to tables when clicking. Culprit was that Desmos doesn't add an empty tail to table columns anymore.